### PR TITLE
Match file name capitilizations. 

### DIFF
--- a/cmake/imgui.cmake
+++ b/cmake/imgui.cmake
@@ -15,8 +15,8 @@ add_library(imgui STATIC
     dependencies/imgui/backends/imgui_impl_glfw.h
     dependencies/imgui/backends/imgui_impl_opengl3.cpp
     dependencies/imgui/backends/imgui_impl_opengl3.h
-    dependencies/imguizmo/imguizmo.cpp
-    dependencies/imguizmo/imguizmo.h
+    dependencies/imguizmo/ImGuizmo.cpp
+    dependencies/imguizmo/ImGuizmo.h
 )
 
 target_include_directories(imgui PUBLIC "${CMAKE_SOURCE_DIR}/dependencies/imgui")

--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -4,7 +4,7 @@
 #include <imgui.h>
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_opengl3.h>
-#include <imguizmo.h>
+#include <ImGuizmo.h>
 #include <GLFW/glfw3.h>
 
 #include <cmrc/cmrc.hpp>


### PR DESCRIPTION
Compiled on windows but linux is case sensitive.